### PR TITLE
add missing signal header to response.c

### DIFF
--- a/src/response.c
+++ b/src/response.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <unistd.h>
+#include <signal.h>
 
 #include "config.h"
 #include "socket.h"


### PR DESCRIPTION
It's a small fix, `ppserver` fails to build on Arch Linux due to a missing header.